### PR TITLE
Modified Flickr SQL to return distinct Photos for big hotspots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,83 +2,100 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>wherecamp2015.hackathon</groupId>
-  <artifactId>phumblr-server</artifactId>
-  <version>1.0-SNAPSHOT</version>
+    <groupId>wherecamp2015.hackathon</groupId>
+    <artifactId>phumblr-server</artifactId>
+    <version>1.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <properties>
-    <java.version>1.8</java.version>
-    <geotools.version>14.0</geotools.version>
-  </properties>
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.3.0.RELEASE</version>
-  </parent>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-      <version>1.3.0.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.6.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
-    </dependency>
-    <!-- Postgres -->
-    <dependency>
-      <groupId>postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>9.1-901-1.jdbc4</version>
-    </dependency>
-    <!-- Flickr -->
-    <dependency>
-      <groupId>com.flickr4java</groupId>
-      <artifactId>flickr4java</artifactId>
-      <version>2.13</version>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
+    <parent>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
+        <artifactId>spring-boot-starter-parent</artifactId>
         <version>1.3.0.RELEASE</version>
-        <configuration>
-          <mainClass>org.wherecamp.hackathon.phumblr.service.PhumblrApplication</mainClass>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-dbcp</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <!-- Postgres -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.4-1200-jdbc41</version>
+        </dependency>
+
+
+        <!-- Flickr -->
+        <dependency>
+            <groupId>com.flickr4java</groupId>
+            <artifactId>flickr4java</artifactId>
+            <version>2.13</version>
+        </dependency>
+    </dependencies>
+
+
+
+    <properties>
+        <java.version>1.8</java.version>
+        <geotools.version>14.0</geotools.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <start-class>org.wherecamp.hackathon.phumblr.service.PhumblrApplication</start-class>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>1.3.0.RELEASE</version>
+                <!-- <configuration>
+                  <mainClass>org.wherecamp.hackathon.phumblr.service.PhumblrApplication</mainClass>
+                </configuration>-->
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+<!--
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-dbcp</artifactId>
             <version>${tomcat.version}</version>
         </dependency>
+        -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -75,6 +83,14 @@
             <artifactId>flickr4java</artifactId>
             <version>2.13</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.8.8</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 
@@ -91,11 +107,16 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>1.3.0.RELEASE</version>
-                <!-- <configuration>
+                <configuration>
                   <mainClass>org.wherecamp.hackathon.phumblr.service.PhumblrApplication</mainClass>
-                </configuration>-->
+                </configuration>
             </plugin>
         </plugins>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources</directory>
+            </testResource>
+        </testResources>
     </build>
 
 </project>

--- a/script/7_import_heatmap_to_postgis.sh
+++ b/script/7_import_heatmap_to_postgis.sh
@@ -51,6 +51,33 @@ from flickr f, flickr_heatmap h
 where ST_Contains(h.geom, f.geom)
 group by hotspot_id, owner
 
+
+-- create new chace for photoid
+drop table hotspot_photo_cache;
+create table hotspot_photo_cache as
+select h.gid as hotspot_id,
+photo_id,
+f.views
+from flickr f, flickr_heatmap h
+where ST_Contains(h.geom, f.geom);
+
+CREATE INDEX hotspot_photo_id_idx
+ON hotspot_photo_cache
+USING btree
+(hotspot_id);
+
+CREATE INDEX hotspot_photo_pid_idx
+ON hotspot_photo_cache
+USING btree
+(photo_id COLLATE pg_catalog."default");
+
+CREATE INDEX hotspot_photo_views_idx
+ON hotspot_photo_cache
+USING btree
+(views);
+
+
+
 select f.owner, f.views, f.photo_id
 from flickr f, hotspot_cache c
 where 	c.hotspot_id = 45

--- a/script/7_import_heatmap_to_postgis.sh
+++ b/script/7_import_heatmap_to_postgis.sh
@@ -59,7 +59,10 @@ select h.gid as hotspot_id,
 photo_id,
 f.views
 from flickr f, flickr_heatmap h
-where ST_Contains(h.geom, f.geom);
+where ST_Contains(h.geom, f.geom)
+and views >=5
+group by photo_id, views, hotspot_id
+order by hotspot_id, views desc;
 
 CREATE INDEX hotspot_photo_id_idx
 ON hotspot_photo_cache

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/DataBaseConfig.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/DataBaseConfig.java
@@ -1,0 +1,28 @@
+package org.wherecamp.hackathon.phumblr.service;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+/**
+ * Created by kilobike on 24.02.16.
+ */
+@Configuration
+@ConfigurationProperties
+@ComponentScan
+public class DataBaseConfig {
+
+    @Primary
+    @Bean
+    @ConfigurationProperties("spring.datasource")
+    public DataSource dataSource() {
+        DataSource ds = DataSourceBuilder.create().build();
+        return ds;
+    }
+}
+

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/FlickrConfig.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/FlickrConfig.java
@@ -1,0 +1,25 @@
+package org.wherecamp.hackathon.phumblr.service;
+
+/**
+ * Created by kilo on 20.02.16.
+ */
+public class FlickrConfig {
+    private String flickrKey;
+    private String flickrSecureKey;
+
+    public String getFlickrKey() {
+        return flickrKey;
+    }
+
+    public void setFlickrKey(String flickrKey) {
+        this.flickrKey = flickrKey;
+    }
+
+    public String getFlickrSecureKey() {
+        return flickrSecureKey;
+    }
+
+    public void setFlickrSecureKey(String flickrSecureKey) {
+        this.flickrSecureKey = flickrSecureKey;
+    }
+}

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrApplication.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrApplication.java
@@ -82,4 +82,20 @@ public class PhumblrApplication {
         bean.afterPropertiesSet();
         return (DataSource)bean.getObject();
     }
+
+
+    @Value("${flickrKey}")
+    private String flickrKey;
+
+    @Value("${flickrSecureKey}")
+    private String flickrSecureKey;
+
+    @Bean(destroyMethod="")
+    public FlickrConfig flickrConfig() {
+        LOGGER.info("getting flickr config");
+        FlickrConfig fc = new FlickrConfig();
+        fc.setFlickrKey(flickrKey);
+        fc.setFlickrSecureKey(flickrSecureKey);
+        return fc;
+    }
 }

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrApplication.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrApplication.java
@@ -1,17 +1,25 @@
 package org.wherecamp.hackathon.phumblr.service;
 
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
 import org.apache.log4j.Logger;
+import org.apache.tomcat.util.descriptor.web.ContextResource;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Controller;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 
-import java.io.InputStream;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Properties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jndi.JndiObjectFactoryBean;
+
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
 
 /**
  * Created by danielt on 26.11.15.
@@ -19,53 +27,59 @@ import java.util.Properties;
 @SpringBootApplication
 public class PhumblrApplication {
 
-  private final static Logger LOGGER = Logger.getLogger(PhumblrApplication.class);
-  private static Properties properties;
+    private final static Logger LOGGER = Logger.getLogger(PhumblrApplication.class);
 
-
-  public static Properties getProperties(){
-    if(properties != null){
-      return properties;
-    }
-    try{
-      final InputStream stream = PhumblrApplication.class.getClassLoader().getResourceAsStream("server.properties");
-      properties = new Properties();
-      properties.load(stream);
-      stream.close();
-      return properties;
-    } catch (Exception e) {
-      LOGGER.error("properties not found -> will exit! ",e);
-      System.exit(0);
-      return null;
-    }
-  }
-
-  public static Connection openPostgresConnection(){
-    Properties server = PhumblrApplication.getProperties();
-
-    String host = server.getProperty("pg_host");
-    String port = server.getProperty("pg_port");
-    String db = server.getProperty("pg_db");
-    String user = server.getProperty("pg_user");
-    String pw = server.getProperty("pg_pass");
-
-    try {
-      return DriverManager.getConnection(
-          "jdbc:postgresql://"+host+":"+port+"/"+db, user, pw);
-    } catch (SQLException e) {
-      LOGGER.error("unable to open connection! -> will exit! ",e);
-      System.exit(0);
-      return null;
+    public static void main(String[] args) throws Exception {
+        SpringApplication.run(PhumblrHttpController.class, args);
     }
 
-  }
 
-  public static void main(String[] args) throws Exception {
-    SpringApplication.run(PhumblrHttpController.class, args);
-    Class.forName("org.postgresql.Driver");
+    @Bean
+    public TomcatEmbeddedServletContainerFactory tomcatFactory() {
+        return new TomcatEmbeddedServletContainerFactory() {
 
-    Connection conn = PhumblrApplication.openPostgresConnection();
-    LOGGER.info("Connection check: "+(!conn.isClosed()));
-  }
+            @Value("${app.pg.host}")
+            private String host;
 
+            @Value("${app.pg.port}")
+            private String port;
+
+            @Value("${app.pg.db}")
+            private String db;
+
+            @Value("${app.pg.user}")
+            private String user;
+
+            @Value("${app.pg.pass}")
+            private String password;
+
+            @Override
+            protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(Tomcat tomcat) {
+                tomcat.enableNaming();
+                return super.getTomcatEmbeddedServletContainer(tomcat);
+            }
+
+            @Override
+            protected void postProcessContext(Context context) {
+                ContextResource resource = new ContextResource();
+                resource.setName("jdbc/phumblr");
+                resource.setType(DataSource.class.getName());
+                resource.setProperty("driverClassName", "org.postgresql.Driver");
+                resource.setProperty("url", "jdbc:postgresql://"+host+":"+port+"/"+db);
+                resource.setProperty("username", user);
+                resource.setProperty("password", password);
+                context.getNamingResources().addResource(resource);
+            }
+        };
+    }
+
+    @Bean(destroyMethod="")
+    public DataSource jndiDataSource() throws IllegalArgumentException, NamingException {
+        JndiObjectFactoryBean bean = new JndiObjectFactoryBean();
+        bean.setJndiName("java:comp/env/jdbc/phumblr");
+        bean.setProxyInterface(DataSource.class);
+        bean.setLookupOnStartup(false);
+        bean.afterPropertiesSet();
+        return (DataSource)bean.getObject();
+    }
 }

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrApplication.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrApplication.java
@@ -1,24 +1,12 @@
 package org.wherecamp.hackathon.phumblr.service;
 
-import org.apache.catalina.Context;
-import org.apache.catalina.startup.Tomcat;
 import org.apache.log4j.Logger;
-import org.apache.tomcat.util.descriptor.web.ContextResource;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
-
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.jndi.JndiObjectFactoryBean;
 
-import javax.naming.NamingException;
-import javax.sql.DataSource;
+
 
 
 /**
@@ -34,63 +22,13 @@ public class PhumblrApplication {
     }
 
 
-    @Bean
-    public TomcatEmbeddedServletContainerFactory tomcatFactory() {
-        return new TomcatEmbeddedServletContainerFactory() {
-
-            @Value("${app.pg.host}")
-            private String host;
-
-            @Value("${app.pg.port}")
-            private String port;
-
-            @Value("${app.pg.db}")
-            private String db;
-
-            @Value("${app.pg.user}")
-            private String user;
-
-            @Value("${app.pg.pass}")
-            private String password;
-
-            @Override
-            protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(Tomcat tomcat) {
-                tomcat.enableNaming();
-                return super.getTomcatEmbeddedServletContainer(tomcat);
-            }
-
-            @Override
-            protected void postProcessContext(Context context) {
-                ContextResource resource = new ContextResource();
-                resource.setName("jdbc/phumblr");
-                resource.setType(DataSource.class.getName());
-                resource.setProperty("driverClassName", "org.postgresql.Driver");
-                resource.setProperty("url", "jdbc:postgresql://"+host+":"+port+"/"+db);
-                resource.setProperty("username", user);
-                resource.setProperty("password", password);
-                context.getNamingResources().addResource(resource);
-            }
-        };
-    }
-
-    @Bean(destroyMethod="")
-    public DataSource jndiDataSource() throws IllegalArgumentException, NamingException {
-        JndiObjectFactoryBean bean = new JndiObjectFactoryBean();
-        bean.setJndiName("java:comp/env/jdbc/phumblr");
-        bean.setProxyInterface(DataSource.class);
-        bean.setLookupOnStartup(false);
-        bean.afterPropertiesSet();
-        return (DataSource)bean.getObject();
-    }
-
-
     @Value("${flickrKey}")
     private String flickrKey;
 
     @Value("${flickrSecureKey}")
     private String flickrSecureKey;
 
-    @Bean(destroyMethod="")
+    @Bean
     public FlickrConfig flickrConfig() {
         LOGGER.info("getting flickr config");
         FlickrConfig fc = new FlickrConfig();

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
@@ -46,20 +46,33 @@ public class PhumblrHttpController {
         return "DataSource retrieved from JNDI using JndiObjectFactoryBean: " + dataSource;
     }
 
-
-    @RequestMapping("/direct")
-    @ResponseBody
-    public String direct() throws NamingException {
-        return "DataSource retrieved directly from JNDI: " +
-                new InitialContext().lookup("java:comp/env/jdbc/phumblr");
-    }
 */
+    @RequestMapping("/simple")
+    @ResponseBody
+    public String simple(@RequestParam(value="lat") Double lat,
+                              @RequestParam(value="lon") Double lon){
+        FlickrHotspotRepository repo = new FlickrHotspotRepository(dataSource,flickrConfig);
+        try {
+            HotspotPojo flickrHotspot = repo.getHeatmap(lat, lon, false, false);
+            if(flickrHotspot!=null && flickrHotspot.flickr!=null && flickrHotspot.flickr.size()>0) {
+                ObjectMapper mapper = createJacksonMapper();
+                String json = mapper.writeValueAsString(flickrHotspot);
+                return json;
+            }
+        } catch (SQLException e) {
+            LOGGER.error("SQL Exception in Controller: " + e.getLocalizedMessage(), e);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Jackson Exception in Controller: " + e.getLocalizedMessage(), e);
+        }
+        return "{}";
+    }
+
     @RequestMapping("/live")
     public String operational(@RequestParam(value="lat") Double lat,
                               @RequestParam(value="lon") Double lon){
         FlickrHotspotRepository repo = new FlickrHotspotRepository(dataSource,flickrConfig);
         try {
-            HotspotPojo flickrHotspot = repo.getHeatmap(lat, lon);
+            HotspotPojo flickrHotspot = repo.getHeatmap(lat, lon, true, true);
             if(flickrHotspot!=null && flickrHotspot.flickr!=null && flickrHotspot.flickr.size()>0) {
                 ObjectMapper mapper = createJacksonMapper();
                 String json = mapper.writeValueAsString(flickrHotspot);

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
@@ -1,8 +1,7 @@
 package org.wherecamp.hackathon.phumblr.service;
 
 
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
+
 import javax.sql.DataSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -12,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.wherecamp.hackathon.phumblr.service.flickr.FlickrHotspotRepository;
 
 import java.sql.SQLException;
+import java.util.List;
 
 /**
  * Created by danielt on 26.11.15.
@@ -37,14 +38,24 @@ public class PhumblrHttpController {
     private final static Logger LOGGER = Logger.getLogger(PhumblrHttpController.class);
 
 
-/*
-    @RequestMapping("/factoryBean")
+
+    @RequestMapping("/WikiInfo")
     @ResponseBody
-    public String factoryBean() {
-        return "DataSource retrieved from JNDI using JndiObjectFactoryBean: " + dataSource;
+    public String factoryBean(@RequestParam(value="hotspotid") Integer hotspotId) {
+        FlickrHotspotRepository repo = new FlickrHotspotRepository(dataSource,flickrConfig);
+        try {
+           List<WikiPojo> hotspots = repo.loadWikis(hotspotId);
+
+                ObjectMapper mapper = createJacksonMapper();
+                String json = mapper.writeValueAsString(hotspots);
+                return json;
+        } catch (Exception e) {
+            LOGGER.error( e.getLocalizedMessage(), e);
+        }
+        return "generating wiki data failed for id: " + hotspotId;
     }
 
-*/
+
     @RequestMapping("/simple")
     @ResponseBody
     public String simple(@RequestParam(value="lat") Double lat,

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
@@ -1,13 +1,21 @@
 package org.wherecamp.hackathon.phumblr.service;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.wherecamp.hackathon.phumblr.service.flickr.FlickrHotspotRepository;
 
@@ -16,84 +24,103 @@ import java.sql.SQLException;
 /**
  * Created by danielt on 26.11.15.
  */
+@ComponentScan
 @Configuration
 @EnableAutoConfiguration
 @RestController
 public class PhumblrHttpController {
 
-  private final static Logger LOGGER = Logger.getLogger(PhumblrHttpController.class);
+    @Autowired
+    private DataSource dataSource;
+    private final static Logger LOGGER = Logger.getLogger(PhumblrHttpController.class);
 
-  @RequestMapping("/live")
-  public String operational(@RequestParam(value="lat") Double lat,
-                                   @RequestParam(value="lon") Double lon){
-    FlickrHotspotRepository repo = new FlickrHotspotRepository();
-    try {
-      HotspotPojo flickrHotspot = repo.getHeatmap(lat, lon);
-      if(flickrHotspot!=null && flickrHotspot.flickr!=null && flickrHotspot.flickr.size()>0) {
-        ObjectMapper mapper = createJacksonMapper();
-        String json = mapper.writeValueAsString(flickrHotspot);
-        return json;
-      }
-    } catch (SQLException e) {
-      LOGGER.error("SQL Exception in Controller: " + e.getLocalizedMessage(), e);
-    } catch (JsonProcessingException e) {
-      LOGGER.error("Jackson Exception in Controller: " + e.getLocalizedMessage(), e);
+
+
+    @RequestMapping("/factoryBean")
+    @ResponseBody
+    public String factoryBean() {
+        return "DataSource retrieved from JNDI using JndiObjectFactoryBean: " + dataSource;
     }
-    return "{}";
-  }
 
-  private ObjectMapper createJacksonMapper(){
-    ObjectMapper mapper = new ObjectMapper();
+
+    @RequestMapping("/direct")
+    @ResponseBody
+    public String direct() throws NamingException {
+        return "DataSource retrieved directly from JNDI: " +
+                new InitialContext().lookup("java:comp/env/jdbc/phumblr");
+    }
+
+    @RequestMapping("/live")
+    public String operational(@RequestParam(value="lat") Double lat,
+                              @RequestParam(value="lon") Double lon){
+        FlickrHotspotRepository repo = new FlickrHotspotRepository(dataSource);
+        try {
+            HotspotPojo flickrHotspot = repo.getHeatmap(lat, lon);
+            if(flickrHotspot!=null && flickrHotspot.flickr!=null && flickrHotspot.flickr.size()>0) {
+                ObjectMapper mapper = createJacksonMapper();
+                String json = mapper.writeValueAsString(flickrHotspot);
+                return json;
+            }
+        } catch (SQLException e) {
+            LOGGER.error("SQL Exception in Controller: " + e.getLocalizedMessage(), e);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Jackson Exception in Controller: " + e.getLocalizedMessage(), e);
+        }
+        return "{}";
+    }
+
+    private ObjectMapper createJacksonMapper(){
+        ObjectMapper mapper = new ObjectMapper();
     /*mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker().
         withGetterVisibility(JsonAutoDetect.Visibility.NONE).
         withSetterVisibility(JsonAutoDetect.Visibility.NONE));
     */
-    return mapper;
-  }
+        return mapper;
+    }
 
-  @RequestMapping("/")
-  public String mock(@RequestParam(value="lat") Double lat,
-                     @RequestParam(value="lon") Double lon){
-    return "{\n" +
-        "\t\"flickr\":[\n" +
-        "\t\t{\n" +
-        "\t\t\t\"url\":\"http://flickr...\",\n" +
-        "\t\t\t\"views\":123\n" +
-        "\t\t},\n" +
-        "\t\t{\n" +
-        "\t\t\t\"url\":\"http://flickr...\",\n" +
-        "\t\t\t\"views\":123\n" +
-        "\t\t}\n" +
-        "\t\t\n" + //minimum 5
-        "\t],\n" +
-        "\n" +
-        "\t\"wiki\":[\n" +
-        "\t\t{\n" +
-        "\t\t\t\"title\":\"Hauptbahnhof\",\n" + //human readble
-        "\t\t\t\"distanceFromLocationInMeter\":123,\n" +
-        "\t\t\t\"sections\":[\n" +
-        "\t\t\t\t{\n" +
-        "\t\t\t\t\t\"title\":\"History\",\n" +
-        "\t\t\t\t\t\"content\":\"bla\"\n" +
-        "\t\t\t\t}\n" +
-        "\t\t\t\t\n" + //...
-        "\t\t\t]\n" +
-        "\t\t},\n" +
-        "\t\t{\n" +
-        "\t\t\t\"title\":\"Hauptbahnhof\",\t\t\n" +//human readble
-        "\t\t\t\"distanceInMeter\":123,\n" +
-        "\t\t\t\"sections\":[\n" +
-        "\t\t\t\t{\n" +
-        "\t\t\t\t\t\"title\":\"History\",\n" +
-        "\t\t\t\t\t\"content\":\"bla\"\n" +
-        "\t\t\t\t}\n" +
-        "\t\t\t\t\n" + //...
-        "\t\t\t]\n" +
-        "\t\t}\n" +
-        "\t\t\n" + //all within 500m
-        "\t]\n" +
-        "}";
-  }
+    @RequestMapping("/")
+    public String mock(@RequestParam(value="lat") Double lat,
+                       @RequestParam(value="lon") Double lon){
+        return "{\n" +
+                "\t\"flickr\":[\n" +
+                "\t\t{\n" +
+                "\t\t\t\"url\":\"http://flickr...\",\n" +
+                "\t\t\t\"views\":123\n" +
+                "\t\t},\n" +
+                "\t\t{\n" +
+                "\t\t\t\"url\":\"http://flickr...\",\n" +
+                "\t\t\t\"views\":123\n" +
+                "\t\t}\n" +
+                "\t\t\n" + //minimum 5
+                "\t],\n" +
+                "\n" +
+                "\t\"wiki\":[\n" +
+                "\t\t{\n" +
+                "\t\t\t\"title\":\"Hauptbahnhof\",\n" + //human readble
+                "\t\t\t\"distanceFromLocationInMeter\":123,\n" +
+                "\t\t\t\"sections\":[\n" +
+                "\t\t\t\t{\n" +
+                "\t\t\t\t\t\"title\":\"History\",\n" +
+                "\t\t\t\t\t\"content\":\"bla\"\n" +
+                "\t\t\t\t}\n" +
+                "\t\t\t\t\n" + //...
+                "\t\t\t]\n" +
+                "\t\t},\n" +
+                "\t\t{\n" +
+                "\t\t\t\"title\":\"Hauptbahnhof\",\t\t\n" +//human readble
+                "\t\t\t\"distanceInMeter\":123,\n" +
+                "\t\t\t\"sections\":[\n" +
+                "\t\t\t\t{\n" +
+                "\t\t\t\t\t\"title\":\"History\",\n" +
+                "\t\t\t\t\t\"content\":\"bla\"\n" +
+                "\t\t\t\t}\n" +
+                "\t\t\t\t\n" + //...
+                "\t\t\t]\n" +
+                "\t\t}\n" +
+                "\t\t\n" + //all within 500m
+                "\t]\n" +
+                "}";
+    }
 
 }
 

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/PhumblrHttpController.java
@@ -32,10 +32,14 @@ public class PhumblrHttpController {
 
     @Autowired
     private DataSource dataSource;
+
+    @Autowired
+    private FlickrConfig flickrConfig;
+
     private final static Logger LOGGER = Logger.getLogger(PhumblrHttpController.class);
 
 
-
+/*
     @RequestMapping("/factoryBean")
     @ResponseBody
     public String factoryBean() {
@@ -49,11 +53,11 @@ public class PhumblrHttpController {
         return "DataSource retrieved directly from JNDI: " +
                 new InitialContext().lookup("java:comp/env/jdbc/phumblr");
     }
-
+*/
     @RequestMapping("/live")
     public String operational(@RequestParam(value="lat") Double lat,
                               @RequestParam(value="lon") Double lon){
-        FlickrHotspotRepository repo = new FlickrHotspotRepository(dataSource);
+        FlickrHotspotRepository repo = new FlickrHotspotRepository(dataSource,flickrConfig);
         try {
             HotspotPojo flickrHotspot = repo.getHeatmap(lat, lon);
             if(flickrHotspot!=null && flickrHotspot.flickr!=null && flickrHotspot.flickr.size()>0) {

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrApiDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrApiDatasource.java
@@ -6,14 +6,7 @@ import com.flickr4java.flickr.REST;
 import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photos.Size;
 import org.apache.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Controller;
-import org.springframework.stereotype.Service;
+
 import org.wherecamp.hackathon.phumblr.service.FlickrConfig;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrApiDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrApiDatasource.java
@@ -6,6 +6,15 @@ import com.flickr4java.flickr.REST;
 import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photos.Size;
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Controller;
+import org.springframework.stereotype.Service;
+import org.wherecamp.hackathon.phumblr.service.FlickrConfig;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -14,17 +23,33 @@ import java.util.ArrayList;
 /**
  * Created by danielt on 27.11.15.
  */
+
 public class FlickrApiDatasource {
 
   private Logger LOGGER = Logger.getLogger(FlickrApiDatasource.class);
 
-  private String flickrKey = "7ad8ddffead4f54320ac26f57ab8c6ea";
-  private String flickrSecureKey = "7eb755f2b10a6cd2";
   private PhotosInterface flickrInterface;
 
+  private FlickrConfig flickrConfig;
+
   FlickrApiDatasource(){
-    flickrInterface = new Flickr(flickrKey, flickrSecureKey, new REST()).getPhotosInterface();
+    super();
+    if(flickrConfig != null) {
+      flickrInterface = new Flickr(flickrConfig.getFlickrKey(), flickrConfig.getFlickrSecureKey(), new REST()).getPhotosInterface();
+    }
   }
+
+
+  FlickrApiDatasource(FlickrConfig flickrConfig){
+    this.flickrConfig = flickrConfig;
+    flickrInterface = new Flickr(flickrConfig.getFlickrKey(), flickrConfig.getFlickrSecureKey(), new REST()).getPhotosInterface();
+  }
+
+  public void setFlickrConfig(FlickrConfig flickrConfig) {
+    this.flickrConfig = flickrConfig;
+    flickrInterface = new Flickr(flickrConfig.getFlickrKey(), flickrConfig.getFlickrSecureKey(), new REST()).getPhotosInterface();
+  }
+
 
   public URL getPhotoUrl(Long photoId, int maxSize){
     try {

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrApiDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrApiDatasource.java
@@ -7,6 +7,10 @@ import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photos.Size;
 import org.apache.log4j.Logger;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.wherecamp.hackathon.phumblr.service.FlickrConfig;
 
 import java.net.MalformedURLException;
@@ -16,13 +20,16 @@ import java.util.ArrayList;
 /**
  * Created by danielt on 27.11.15.
  */
-
+@ComponentScan("org.wherecamp.hackathon.phumblr.service")
+@EnableAutoConfiguration
+@Configuration
 public class FlickrApiDatasource {
 
   private Logger LOGGER = Logger.getLogger(FlickrApiDatasource.class);
 
   private PhotosInterface flickrInterface;
 
+  @Autowired
   private FlickrConfig flickrConfig;
 
   FlickrApiDatasource(){

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -1,9 +1,15 @@
 package org.wherecamp.hackathon.phumblr.service.flickr;
 
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 import org.wherecamp.hackathon.phumblr.service.FlickrPojo;
 import org.wherecamp.hackathon.phumblr.service.PhumblrApplication;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -14,91 +20,108 @@ import java.util.List;
 /**
  * Created by danielt on 27.11.15.
  */
+
+@ComponentScan
+@Configuration
+@EnableAutoConfiguration
+@Component
 public class FlickrDatabaseDatasource {
 
-  Logger LOGGER = Logger.getLogger(FlickrDatabaseDatasource.class);
+    Logger LOGGER = Logger.getLogger(FlickrDatabaseDatasource.class);
 
-  public Integer loadHotspotGid(double lat, double lon) throws SQLException {
-    StringBuffer sql = new StringBuffer()
-        .append(" select")
-        .append("   gid")
-        .append(" from")
-        .append("   flickr_heatmap")
-        .append(" where")
-        .append("   ST_Contains(")
-        .append("     geom,")
-        .append("     ST_Transform(")
-        .append("       ST_SetSRID(ST_MakePoint("+lon+", "+lat+"),4326),")
-        .append("       25833")
-        .append("     )")
-        .append("   ) ");
+    private DataSource dataSource;
 
-    LOGGER.info(sql.toString());
-
-    Connection conn = PhumblrApplication.openPostgresConnection();
-    Statement stmt = null;
-    ResultSet rs = null;
-    try{
-      stmt = conn.createStatement();
-      rs = stmt.executeQuery(sql.toString());
-      if(rs.next()){
-        Long gid = rs.getLong("gid");
-        return gid.intValue();
-      }
-      return null;
-    } catch (SQLException e) {
-      LOGGER.error("error while loadHotspotGid: "+e.getLocalizedMessage(), e);
-      throw e;
-    } finally {
-      try {
-        rs.close();
-        stmt.close();
-        conn.close();
-      } catch (SQLException e) {
-        LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
-      }
+    public FlickrDatabaseDatasource(DataSource dataSource){
+        this.dataSource = dataSource;
     }
-  }
+    public FlickrDatabaseDatasource(){
+        this.dataSource = null;
 
-  public List<FlickrPojo> loadRelevantPhotos(Integer gid, int amount) throws SQLException {
-
-	  StringBuffer sql = new StringBuffer()
-		        .append("SELECT distinct h.photo_id, f.views  as views "+
-	  "from hotspot_photo_cache h left join flickr f on h.photo_id = f.photo_id "+
-	  "where hotspot_id = " + gid +
-	  " order by f.views desc "+
-	  " limit "+ amount);
-	  
-    LOGGER.info(sql.toString());
-
-    Connection conn = PhumblrApplication.openPostgresConnection();
-    Statement stmt = null;
-    ResultSet rs = null;
-    try{
-      stmt = conn.createStatement();
-      LOGGER.info("statement created");
-      rs = stmt.executeQuery(sql.toString());
-      LOGGER.info("statement executed");
-      List<FlickrPojo> photos = new ArrayList<>();
-      while(rs.next()){
-        FlickrPojo photo = new FlickrPojo();
-        photo.views = rs.getInt("views");
-        photo.photoId = rs.getLong("photo_id");
-        photos.add(photo);
-      }
-      LOGGER.info("returning...");
-      return photos;
-    } catch (SQLException e) {
-      LOGGER.error("error while loadRelevantPhotos: "+e.getLocalizedMessage(), e);
-      throw e;
-    } finally {
-      try {
-        rs.close();
-        stmt.close();
-        conn.close();
-      } catch (SQLException e) {
-        LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
-      }
     }
-  }
+
+    public Integer loadHotspotGid(double lat, double lon) throws SQLException {
+        StringBuffer sql = new StringBuffer()
+                .append(" select")
+                .append("   gid")
+                .append(" from")
+                .append("   flickr_heatmap")
+                .append(" where")
+                .append("   ST_Contains(")
+                .append("     geom,")
+                .append("     ST_Transform(")
+                .append("       ST_SetSRID(ST_MakePoint("+lon+", "+lat+"),4326),")
+                .append("       25833")
+                .append("     )")
+                .append("   ) ");
+
+        LOGGER.info(sql.toString());
+
+
+
+        Connection conn = dataSource.getConnection();//PhumblrApplication.openPostgresConnection();
+        Statement stmt = null;
+        ResultSet rs = null;
+        try{
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery(sql.toString());
+            if(rs.next()){
+                Long gid = rs.getLong("gid");
+                return gid.intValue();
+            }
+            return null;
+        } catch (SQLException e) {
+            LOGGER.error("error while loadHotspotGid: "+e.getLocalizedMessage(), e);
+            throw e;
+        } finally {
+            try {
+                rs.close();
+                stmt.close();
+                conn.close();
+            } catch (SQLException e) {
+                LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
+            }
+        }
+    }
+
+    public List<FlickrPojo> loadRelevantPhotos(Integer gid, int amount) throws SQLException {
+
+        StringBuffer sql = new StringBuffer()
+                .append("SELECT distinct h.photo_id, f.views  as views "+
+                        "from hotspot_photo_cache h left join flickr f on h.photo_id = f.photo_id "+
+                        "where hotspot_id = " + gid +
+                        " order by f.views desc "+
+                        " limit "+ amount);
+
+        LOGGER.info(sql.toString());
+
+        Connection conn = dataSource.getConnection(); //PhumblrApplication.openPostgresConnection();
+        Statement stmt = null;
+        ResultSet rs = null;
+        try{
+            stmt = conn.createStatement();
+            LOGGER.info("statement created");
+            rs = stmt.executeQuery(sql.toString());
+            LOGGER.info("statement executed");
+            List<FlickrPojo> photos = new ArrayList<>();
+            while(rs.next()){
+                FlickrPojo photo = new FlickrPojo();
+                photo.views = rs.getInt("views");
+                photo.photoId = rs.getLong("photo_id");
+                photos.add(photo);
+            }
+            LOGGER.info("returning...");
+            return photos;
+        } catch (SQLException e) {
+            LOGGER.error("error while loadRelevantPhotos: "+e.getLocalizedMessage(), e);
+            throw e;
+        } finally {
+            try {
+                rs.close();
+                stmt.close();
+                conn.close();
+            } catch (SQLException e) {
+                LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
+            }
+        }
+    }
 }

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -73,7 +73,7 @@ public class FlickrDatabaseDatasource {
         .append(" limit "+amount);
     */
     StringBuffer sql = new StringBuffer()
-        .append("SELECT f.photo_id, max(f.views) as views, max( distinct(f.owner)) as owner "+
+        .append("SELECT f.photo_id, max(f.views) as views "+
                 //"select f.owner, f.views, f.photo_id " +
             " from flickr f, hotspot_cache c " +
             " where c.hotspot_id = "+gid +

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -61,32 +61,11 @@ public class FlickrDatabaseDatasource {
   }
 
   public List<FlickrPojo> loadRelevantPhotos(Integer gid, int amount) throws SQLException {
-    /*StringBuffer sql = new StringBuffer()
-        .append(" select distinct")
-        .append(" f.owner, f.photo_id, f.views, f.date_taken")
-        .append(" from")
-        .append(" flickr f, flickr_heatmap h")
-        .append(" where")
-        .append(" h.gid = "+gid)
-        .append(" and ST_Contains(h.geom, f.geom)")
-        .append(" order by f.views desc")
-        .append(" limit "+amount);
-    */
-   /* StringBuffer sql = new StringBuffer()
-        .append("SELECT f.photo_id, max(f.views) as views "+
-            " from flickr f, hotspot_cache c " +
-            " where c.hotspot_id = "+gid +
-            " and f.owner = c.owner " +
-            " and f.views = c.max_views " +
-            " group by f.photo_id order by views desc " +
-            " limit "+amount);
-*/
-	  
+
 	  StringBuffer sql = new StringBuffer()
-		        .append("SELECT distinct f.photo_id, f.views as views "+
-	  "from hotspot_photo_cache h left join flickr f on f.photo_id = h.photo_id "+
+		        .append("SELECT distinct h.photo_id, f.views  as views "+
+	  "from hotspot_photo_cache h left join flickr f on h.photo_id = f.photo_id "+
 	  "where hotspot_id = " + gid +
-	  " and f.views > 5 "+
 	  " order by f.views desc "+
 	  " limit "+ amount);
 	  
@@ -97,7 +76,9 @@ public class FlickrDatabaseDatasource {
     ResultSet rs = null;
     try{
       stmt = conn.createStatement();
+      LOGGER.info("statement created");
       rs = stmt.executeQuery(sql.toString());
+      LOGGER.info("statement executed");
       List<FlickrPojo> photos = new ArrayList<>();
       while(rs.next()){
         FlickrPojo photo = new FlickrPojo();
@@ -105,6 +86,7 @@ public class FlickrDatabaseDatasource {
         photo.photoId = rs.getLong("photo_id");
         photos.add(photo);
       }
+      LOGGER.info("returning...");
       return photos;
     } catch (SQLException e) {
       LOGGER.error("error while loadRelevantPhotos: "+e.getLocalizedMessage(), e);

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -80,7 +80,7 @@ public class FlickrDatabaseDatasource {
             " and f.owner = c.owner " +
             " and f.views = c.max_views " +
           //  "order by f.views desc " +
-            " group byf.photo_id order by views desc "
+            " group by f.photo_id order by views desc "
             " limit "+amount);
 
     LOGGER.info(sql.toString());

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -72,17 +72,24 @@ public class FlickrDatabaseDatasource {
         .append(" order by f.views desc")
         .append(" limit "+amount);
     */
-    StringBuffer sql = new StringBuffer()
+   /* StringBuffer sql = new StringBuffer()
         .append("SELECT f.photo_id, max(f.views) as views "+
-                //"select f.owner, f.views, f.photo_id " +
             " from flickr f, hotspot_cache c " +
             " where c.hotspot_id = "+gid +
             " and f.owner = c.owner " +
             " and f.views = c.max_views " +
-          //  "order by f.views desc " +
             " group by f.photo_id order by views desc " +
             " limit "+amount);
-
+*/
+	  
+	  StringBuffer sql = new StringBuffer()
+		        .append("SELECT distinct f.photo_id, f.views as views "+
+	  "from hotspot_photo_cache h left join flickr f on f.photo_id = h.photo_id "+
+	  "where hotspot_id = " + gid +
+	  " and f.views > 5 "+
+	  " order by f.views desc "+
+	  " limit "+ amount);
+	  
     LOGGER.info(sql.toString());
 
     Connection conn = PhumblrApplication.openPostgresConnection();

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -58,7 +58,7 @@ public class FlickrDatabaseDatasource {
 
 
 
-        Connection conn = dataSource.getConnection();//PhumblrApplication.openPostgresConnection();
+        Connection conn = dataSource.getConnection();
         Statement stmt = null;
         ResultSet rs = null;
         try{
@@ -116,9 +116,12 @@ public class FlickrDatabaseDatasource {
             throw e;
         } finally {
             try {
-                rs.close();
-                stmt.close();
-                conn.close();
+                if (rs != null)
+                    rs.close();
+                if (stmt != null)
+                    stmt.close();
+                if (conn != null)
+                    conn.close();
             } catch (SQLException e) {
                 LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
             }

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -73,13 +73,15 @@ public class FlickrDatabaseDatasource {
         .append(" limit "+amount);
     */
     StringBuffer sql = new StringBuffer()
-        .append("select f.owner, f.views, f.photo_id " +
-            "from flickr f, hotspot_cache c " +
-            "where c.hotspot_id = "+gid +
+        .append("SELECT f.photo_id, max(f.views) as views, max(distinct(f.owner)) as owner "
+                //"select f.owner, f.views, f.photo_id " +
+            " from flickr f, hotspot_cache c " +
+            " where c.hotspot_id = "+gid +
             " and f.owner = c.owner " +
             " and f.views = c.max_views " +
-            "order by f.views desc " +
-            "limit "+amount);
+          //  "order by f.views desc " +
+            " group byf.photo_id order by views desc "
+            " limit "+amount);
 
     LOGGER.info(sql.toString());
 

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -21,21 +21,21 @@ import java.util.List;
  * Created by danielt on 27.11.15.
  */
 
-@ComponentScan
+@ComponentScan("org.wherecamp.hackathon.phumblr.service")
 @Configuration
 @EnableAutoConfiguration
 @Component
 public class FlickrDatabaseDatasource {
 
     Logger LOGGER = Logger.getLogger(FlickrDatabaseDatasource.class);
-
+    @Autowired
     private DataSource dataSource;
 
     public FlickrDatabaseDatasource(DataSource dataSource){
         this.dataSource = dataSource;
     }
     public FlickrDatabaseDatasource(){
-        this.dataSource = null;
+
 
     }
 

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrDatabaseDatasource.java
@@ -73,14 +73,14 @@ public class FlickrDatabaseDatasource {
         .append(" limit "+amount);
     */
     StringBuffer sql = new StringBuffer()
-        .append("SELECT f.photo_id, max(f.views) as views, max(distinct(f.owner)) as owner "
+        .append("SELECT f.photo_id, max(f.views) as views, max( distinct(f.owner)) as owner "+
                 //"select f.owner, f.views, f.photo_id " +
             " from flickr f, hotspot_cache c " +
             " where c.hotspot_id = "+gid +
             " and f.owner = c.owner " +
             " and f.views = c.max_views " +
           //  "order by f.views desc " +
-            " group by f.photo_id order by views desc "
+            " group by f.photo_id order by views desc " +
             " limit "+amount);
 
     LOGGER.info(sql.toString());

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
@@ -1,5 +1,9 @@
 package org.wherecamp.hackathon.phumblr.service.flickr;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.wherecamp.hackathon.phumblr.service.FlickrConfig;
 import org.wherecamp.hackathon.phumblr.service.FlickrPojo;
 import org.wherecamp.hackathon.phumblr.service.HotspotPojo;
@@ -15,15 +19,27 @@ import javax.sql.DataSource;
 /**
  * Created by danielt on 27.11.15.
  */
+
+@ComponentScan("org.wherecamp.hackathon.phumblr.service")
+@EnableAutoConfiguration
+@Configuration
 public class FlickrHotspotRepository {
 
   Logger LOGGER = Logger.getLogger(FlickrHotspotRepository.class);
 
+  @Autowired
   FlickrConfig flickrConfig;
 
   FlickrApiDatasource flickrData;
 
+  @Autowired
   private DataSource dataSource;
+
+  public FlickrHotspotRepository(){
+
+    LOGGER.info("construct Repository");
+
+  }
   public FlickrHotspotRepository(DataSource dataSource, FlickrConfig flickrConfig){
     this.dataSource = dataSource;
     this.flickrConfig = flickrConfig;
@@ -54,7 +70,7 @@ public class FlickrHotspotRepository {
     return hotspot;
   }
 
-  private List<WikiPojo> loadWikis(Integer gid) throws SQLException {
+  public List<WikiPojo> loadWikis(Integer gid) throws SQLException {
     List<WikiPojo> wikis = new ArrayList<>();
     int amount = 5;
     int maxDistance = 500;
@@ -65,9 +81,6 @@ public class FlickrHotspotRepository {
       List<WikiPojo> wikisAround = wikiSource.loadWikisAroundHotspot(gid, maxDistance, amount - wikisInside.size());
       wikis.addAll(wikisAround);
     }
-
-
-
     return wikis;
   }
 
@@ -76,7 +89,7 @@ public class FlickrHotspotRepository {
   private List<FlickrPojo> loadPhotoIds(FlickrDatabaseDatasource ds, Integer gid) throws SQLException {
     int maxSize = 320;
 
-    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 3);
+    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 15);
 
     LOGGER.info("loadedPhotoUrls");
     return photos;
@@ -85,7 +98,7 @@ public class FlickrHotspotRepository {
   private List<FlickrPojo> loadPhotoUrls(FlickrDatabaseDatasource ds, Integer gid) throws SQLException {
     int maxSize = 320;
 
-    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 3);
+    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 5);
 
     if (flickrData == null){
       LOGGER.info("start flickr init");

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
@@ -49,7 +49,7 @@ public class FlickrHotspotRepository {
 
   private List<FlickrPojo> loadPhotoUrls(FlickrDatabaseDatasource ds, Integer gid) throws SQLException {
     int maxSize = 320;
-    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 5);
+    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 15);
     for(FlickrPojo photo : photos){
       photo.url = new FlickrApiDatasource().getPhotoUrl(photo.photoId, maxSize);
     }

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
@@ -8,16 +8,27 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
+
+import javax.sql.DataSource;
+
 /**
  * Created by danielt on 27.11.15.
  */
 public class FlickrHotspotRepository {
 
-	Logger LOGGER = Logger.getLogger(FlickrHotspotRepository.class);
+  Logger LOGGER = Logger.getLogger(FlickrHotspotRepository.class);
+
+  private DataSource dataSource;
+  public FlickrHotspotRepository(DataSource dataSource){
+    this.dataSource = dataSource;
+
+  }
+
+
 	
   public HotspotPojo getHeatmap(double lat, double lon) throws SQLException {
     HotspotPojo hotspot = new HotspotPojo();
-    FlickrDatabaseDatasource ds = new FlickrDatabaseDatasource();
+    FlickrDatabaseDatasource ds = new FlickrDatabaseDatasource(dataSource);
 
     Integer hotspotId = ds.loadHotspotGid(lat, lon);
     if(hotspotId==null){
@@ -36,7 +47,7 @@ public class FlickrHotspotRepository {
     List<WikiPojo> wikis = new ArrayList<>();
     int amount = 5;
     int maxDistance = 500;
-    WikiDatabaseDatasource wikiSource = new WikiDatabaseDatasource();
+    WikiDatabaseDatasource wikiSource = new WikiDatabaseDatasource(dataSource);
     List<WikiPojo> wikisInside = wikiSource.loadWikisInsideHotspot(gid, amount);
     wikis.addAll(wikisInside);
     if(wikisInside.size()<amount) {

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
@@ -1,5 +1,6 @@
 package org.wherecamp.hackathon.phumblr.service.flickr;
 
+import org.wherecamp.hackathon.phumblr.service.FlickrConfig;
 import org.wherecamp.hackathon.phumblr.service.FlickrPojo;
 import org.wherecamp.hackathon.phumblr.service.HotspotPojo;
 import org.wherecamp.hackathon.phumblr.service.WikiPojo;
@@ -18,10 +19,12 @@ public class FlickrHotspotRepository {
 
   Logger LOGGER = Logger.getLogger(FlickrHotspotRepository.class);
 
-  private DataSource dataSource;
-  public FlickrHotspotRepository(DataSource dataSource){
-    this.dataSource = dataSource;
+  FlickrConfig flickrConfig;
 
+  private DataSource dataSource;
+  public FlickrHotspotRepository(DataSource dataSource, FlickrConfig flickrConfig){
+    this.dataSource = dataSource;
+    this.flickrConfig = flickrConfig;
   }
 
 
@@ -39,7 +42,7 @@ public class FlickrHotspotRepository {
     hotspot.hotspotId = hotspotId;
     hotspot.flickr = loadPhotoUrls(ds, hotspotId);
     hotspot.wiki = loadWikis(hotspotId);
-
+    LOGGER.info("loaded wikis");
     return hotspot;
   }
 
@@ -62,11 +65,13 @@ public class FlickrHotspotRepository {
 
   private List<FlickrPojo> loadPhotoUrls(FlickrDatabaseDatasource ds, Integer gid) throws SQLException {
     int maxSize = 320;
-    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 5);
+    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 3);
+    FlickrApiDatasource flickrData = new FlickrApiDatasource();
+    flickrData.setFlickrConfig(flickrConfig);
     for(FlickrPojo photo : photos){
-      photo.url = new FlickrApiDatasource().getPhotoUrl(photo.photoId, maxSize);
+      photo.url = flickrData.getPhotoUrl(photo.photoId, maxSize);
     }
-    LOGGER.info("loadPhotoUrls");
+    LOGGER.info("loadedPhotoUrls");
     return photos;
   }
 

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/FlickrHotspotRepository.java
@@ -7,12 +7,14 @@ import org.wherecamp.hackathon.phumblr.service.WikiPojo;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.log4j.Logger;
 /**
  * Created by danielt on 27.11.15.
  */
 public class FlickrHotspotRepository {
 
+	Logger LOGGER = Logger.getLogger(FlickrHotspotRepository.class);
+	
   public HotspotPojo getHeatmap(double lat, double lon) throws SQLException {
     HotspotPojo hotspot = new HotspotPojo();
     FlickrDatabaseDatasource ds = new FlickrDatabaseDatasource();
@@ -49,10 +51,11 @@ public class FlickrHotspotRepository {
 
   private List<FlickrPojo> loadPhotoUrls(FlickrDatabaseDatasource ds, Integer gid) throws SQLException {
     int maxSize = 320;
-    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 15);
+    List<FlickrPojo> photos = ds.loadRelevantPhotos(gid, 5);
     for(FlickrPojo photo : photos){
       photo.url = new FlickrApiDatasource().getPhotoUrl(photo.photoId, maxSize);
     }
+    LOGGER.info("loadPhotoUrls");
     return photos;
   }
 

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
@@ -1,11 +1,12 @@
 package org.wherecamp.hackathon.phumblr.service.flickr;
 
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.wherecamp.hackathon.phumblr.service.PhumblrApplication;
 import org.wherecamp.hackathon.phumblr.service.WikiPojo;
 import org.wherecamp.hackathon.phumblr.service.WikiSection;
 
-import java.lang.reflect.Array;
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -23,6 +24,13 @@ public class WikiDatabaseDatasource {
 
   Logger LOGGER = Logger.getLogger(FlickrDatabaseDatasource.class);
 
+  @Autowired
+  DataSource dataSource;
+
+  public WikiDatabaseDatasource(DataSource dataSource){
+    this.dataSource = dataSource;
+  }
+
   public List<WikiPojo> loadWikisInsideHotspot(int hotspotGid, int amount) throws SQLException {
     StringBuffer sql = new StringBuffer()
         .append(" select distinct")
@@ -38,7 +46,7 @@ public class WikiDatabaseDatasource {
 
     LOGGER.info(sql.toString());
 
-    Connection conn = PhumblrApplication.openPostgresConnection();
+    Connection conn = dataSource.getConnection();//PhumblrApplication.openPostgresConnection();
     Statement stmt = null;
     ResultSet rs = null;
     try{
@@ -81,7 +89,7 @@ public class WikiDatabaseDatasource {
 
     LOGGER.info(sql.toString());
 
-    Connection conn = PhumblrApplication.openPostgresConnection();
+    Connection conn = dataSource.getConnection(); //PhumblrApplication.openPostgresConnection();
     Statement stmt = null;
     ResultSet rs = null;
     try{

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
@@ -47,9 +47,11 @@ public class WikiDatabaseDatasource {
         .append(" from")
         .append("   wiki w, flickr_heatmap h")
         .append(" where")
-        .append("   h.gid = "+hotspotGid)
+        .append("   h.gid = ")
+        .append(hotspotGid)
         .append("   and ST_Contains(h.geom, w.geom)")
-        .append(" limit " + amount);
+        .append(" limit ")
+        .append(amount);
 
     LOGGER.info(sql.toString());
 
@@ -70,9 +72,15 @@ public class WikiDatabaseDatasource {
       throw e;
     } finally {
       try {
-        rs.close();
-        stmt.close();
-        conn.close();
+        if (rs != null) {
+          rs.close();
+        }
+        if (stmt != null) {
+          stmt.close();
+        }
+        if (conn != null) {
+          conn.close();
+        }
       } catch (SQLException e) {
         LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
       }
@@ -80,19 +88,21 @@ public class WikiDatabaseDatasource {
   }
 
   public List<WikiPojo> loadWikisAroundHotspot(int hotspotGid, int maxDistanceInMeter, int amount) throws SQLException {
-    StringBuffer sql = new StringBuffer()
+    StringBuilder sql = new StringBuilder()
         .append(" select distinct")
         .append("   w.title, ")
         .append("   ST_Distance(h.geom, w.geom) as distanceFromHotspotInMeter, ")
         .append("   w.sections ")
-        .append(" from")
+        .append(" from ")
         .append("   wiki w, flickr_heatmap h")
-        .append(" where")
-        .append("   h.gid = "+hotspotGid)
+        .append(" where ")
+        .append("   h.gid = ")
+        .append( hotspotGid)
         .append("   and ST_Contains(h.geom, w.geom) = False ")
         .append("   and ST_Contains(ST_Buffer(h.geom, "+maxDistanceInMeter+"), w.geom)")
         .append(" order by distanceFromHotspotInMeter ")
-        .append(" limit " + amount);
+        .append(" limit " )
+        .append(amount);
 
     LOGGER.info(sql.toString());
 
@@ -113,9 +123,15 @@ public class WikiDatabaseDatasource {
       throw e;
     } finally {
       try {
-        rs.close();
-        stmt.close();
-        conn.close();
+        if (rs != null) {
+          rs.close();
+        }
+        if (stmt != null) {
+          stmt.close();
+        }
+        if (conn != null) {
+          conn.close();
+        }
       } catch (SQLException e) {
         LOGGER.error("error while closing stuff: "+e.getLocalizedMessage(), e);
       }
@@ -192,7 +208,7 @@ public class WikiDatabaseDatasource {
 
       while (m.find()) {
         String section_title = m.group(1);
-        if (content != "") temp_sections.add(new String[]{section_title, content});
+        if (!content.equals("")) temp_sections.add(new String[]{section_title, content});
         isContent = false;
         content = "";
       }

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
@@ -2,6 +2,10 @@ package org.wherecamp.hackathon.phumblr.service.flickr;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 import org.wherecamp.hackathon.phumblr.service.PhumblrApplication;
 import org.wherecamp.hackathon.phumblr.service.WikiPojo;
 import org.wherecamp.hackathon.phumblr.service.WikiSection;
@@ -20,12 +24,15 @@ import java.util.regex.Pattern;
 /**
  * Created by danielt on 27.11.15.
  */
+
 public class WikiDatabaseDatasource {
 
   Logger LOGGER = Logger.getLogger(FlickrDatabaseDatasource.class);
-
-  @Autowired
   DataSource dataSource;
+
+  public WikiDatabaseDatasource(){
+    super();
+  }
 
   public WikiDatabaseDatasource(DataSource dataSource){
     this.dataSource = dataSource;

--- a/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
+++ b/src/main/java/org/wherecamp/hackathon/phumblr/service/flickr/WikiDatabaseDatasource.java
@@ -53,7 +53,7 @@ public class WikiDatabaseDatasource {
 
     LOGGER.info(sql.toString());
 
-    Connection conn = dataSource.getConnection();//PhumblrApplication.openPostgresConnection();
+    Connection conn = dataSource.getConnection();
     Statement stmt = null;
     ResultSet rs = null;
     try{
@@ -91,7 +91,7 @@ public class WikiDatabaseDatasource {
         .append("   h.gid = "+hotspotGid)
         .append("   and ST_Contains(h.geom, w.geom) = False ")
         .append("   and ST_Contains(ST_Buffer(h.geom, "+maxDistanceInMeter+"), w.geom)")
-        .append(" order by ST_Distance(h.geom, w.geom) ")
+        .append(" order by distanceFromHotspotInMeter ")
         .append(" limit " + amount);
 
     LOGGER.info(sql.toString());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,9 @@
+spring.datasource.host=localhost
+spring.datasource.port=spring.datasource.db=phumblr
+spring.datasource.user=postgres
+spring.datasource.pass=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
 app.pg.host=localhost
 app.pg.port=5432
 app.pg.db=phumblr

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ app.pg.db=phumblr
 app.pg.user=postgres
 app.pg.pass=postgres
 
+flickrKey=7ad8ddffead4f54320ac26f57ab8c6ea
+flickrSecureKey=7eb755f2b10a6cd2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+app.pg.host=localhost
+app.pg.port=5432
+app.pg.db=phumblr
+app.pg.user=postgres
+app.pg.pass=postgres
+

--- a/src/main/resources/server.properties
+++ b/src/main/resources/server.properties
@@ -1,5 +1,0 @@
-pg_host=localhost
-pg_port=5432
-pg_db=phumblr
-pg_user=postgres
-pg_pass=postgres


### PR DESCRIPTION
If you extract Berlin Alexanderplatz, the previous SQL would return 5 times the same picture. Apparently joining on the various hotspot sections. The modified query will extract distinct images by ordered my  popularity.
